### PR TITLE
strip trailing slashes in URL, to avoid possible double slashes after URL

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -321,6 +321,8 @@ utils.bind = function(fun, that) {
 
 utils.amendUrl = function(url) {
     var dl = _document.location;
+    // falsy url means use current document location as url
+    if (!url) url = dl;
     //  '//abc' --> 'http://abc'
     if (url.indexOf('//') === 0) {
         url = dl.protocol + url;
@@ -329,7 +331,7 @@ utils.amendUrl = function(url) {
     if (url.indexOf('/') === 0) {
         url = dl.protocol + '//' + dl.host + url;
     }
-    return url;
+    return url.replace(/\/+$/,''); // N.B. strip trailing slashes
 };
 
 // IE doesn't support [].indexOf.


### PR DESCRIPTION
strip trailing slashes in URL, to avoid possible double slashes after URL concatenation at https://github.com/majek/sockjs-client/blob/master/lib/sockjs.js#L10 , which can break routing (think of haproxy 2 directory stickiness, shown in example config)

Please, consider applying
--Vladimir
