### PR TITLE
always wrap upstream data in array.

### DIFF
--- a/lib/trans-websocket.js
+++ b/lib/trans-websocket.js
@@ -19,7 +19,7 @@ var WebSocketTransport = SockJS.websocket = function(ri, trans_url) {
 };
 
 WebSocketTransport.prototype.doSend = function(data) {
-    this.ws.send(data);
+    this.ws.send('['+data+']');
 };
 
 WebSocketTransport.prototype.doCleanup = function() {


### PR DESCRIPTION
Currently, websocket transport don't wrap force message wrapped in array, but according to [RFC 4627](http://tools.ietf.org/html/rfc4627#section-2), only object and array are valid top level json, so i propose always wrap upstream data message in an array.
