### PR TITLE
Fix XhrStreamingTransport.enabled for IE 8

### DIFF
--- a/lib/trans-xhr.js
+++ b/lib/trans-xhr.js
@@ -37,9 +37,14 @@ XhrStreamingTransport.prototype = new AjaxBasedTransport();
 XhrStreamingTransport.enabled = function() {
     // Support for CORS Ajax aka Ajax2? Opera 12 claims CORS but
     // doesn't do streaming.
-    return (_window.XMLHttpRequest &&
-            'withCredentials' in new XMLHttpRequest() &&
-            (!/opera/i.test(navigator.userAgent)));
+    try {
+        return (_window.XMLHttpRequest &&
+                'withCredentials' in new XMLHttpRequest() &&
+                (!/opera/i.test(navigator.userAgent)));                                        
+    }
+    catch (ignored) {
+        return false;
+    }
 };
 XhrStreamingTransport.roundTrips = 2; // preflight, ajax
 


### PR DESCRIPTION
This dies with "Object does not support this property or method" om IE8. This is a quick fix to make sockjs work, but I don't know if it's correct. Discuss?
