### PR TITLE
Remove explicit AMD name for greater portability (issue #53).

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,5 +33,5 @@ if ('_sockjs_onload' in window) setTimeout(_sockjs_onload, 1);
 
 // AMD compliance
 if (typeof define === 'function' && define.amd) {
-    define('sockjs', [], function(){return SockJS;});
+    define([], function(){return SockJS;});
 }


### PR DESCRIPTION
From http://requirejs.org/docs/api.html#modulename:

> You can explicitly name modules yourself, but it makes the modules less portable -- if you 
> move the file to another directory you will need to change the name. It is normally best to
> avoid coding in a name for the module ...
