### PR TITLE
Handle empty text in xo.onfinish for JSON.parse (Opera + reconnect and server/internet down)

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -26,7 +26,7 @@ InfoReceiver.prototype.doXhr = function(base_url, AjaxObject) {
         tref = null;
         if (status === 200) {
             var rtt = (new Date()).getTime() - t0;
-            var info = JSON.parse(text);
+            var info = text === '' ? {} : JSON.parse(text);
             if (typeof info !== 'object') info = {};
             that.emit('finish', info, rtt);
         } else {


### PR DESCRIPTION
I had the problem with the current Opera version (12.14) when reconnecting with `new SockJS` after a connection has been closed (i.e. server/internet down). The `text` parameter of `xo.onfinish` on Opera is provided with an empty string if the server is still unavailable. On all other browsers the function is not invoked in that case. If the server is available the function is invoked on the other browsers too and `text` contains `{"websocket":true,"origins":["*:*"],"cookie_needed":false,"entropy":...}`

The fix handles the empty string in `text`so that the following `JSON.parse` does not crash. Maybe it would be better to confirm that the function is not invoked in Opera too like in the other browsers!?
