### PR TITLE
Accept a base URL from /info.

### DIFF
--- a/lib/sockjs.js
+++ b/lib/sockjs.js
@@ -256,6 +256,10 @@ SockJS.prototype._applyInfo = function(info, rtt, protocols_whitelist) {
     that._options.rtt = rtt;
     that._options.rto = utils.countRTO(rtt);
     that._options.info.null_origin = !_document.domain;
+    // Servers can override base_url, eg to provide a randomized domain name and
+    // avoid browser per-domain connection limits.
+    if (info.base_url)
+      that._base_url = utils.amendUrl(info.base_url);
     var probed = utils.probeProtocols();
     that._protocols = utils.detectProtocols(probed, protocols_whitelist, info);
 };


### PR DESCRIPTION
See also sockjs/sockjs-node#118.

The goal here is to allow servers to specify a base URL with a random segment in the domain (all of which are routed to the same place), so that different SockJS connections to the same URL (in different tabs, eg) use different domains and don't run into browser per-domain connection limits.
