### PR TITLE
Don't crash on iOS 5.x when using WebSockets on Safari resume

### DIFF
--- a/lib/trans-websocket.js
+++ b/lib/trans-websocket.js
@@ -35,23 +35,23 @@ var WebSocketTransport = SockJS.websocket = function(ri, trans_url) {
 };
 
 WebSocketTransport.prototype.doSend = function(data) {
-  var self = this;
-  var _send = function () {
-    self.ws.send('[' + data + ']');
-  };
+    var self = this;
+    var _send = function () {
+        self.ws.send('[' + data + ']');
+    };
 
-  if (/iPhone|iPad|iPod/.test(navigator.userAgent) &&
-      /OS 5_0|OS 5_1/.test(navigator.userAgent)) {
-    // On iOS 5.x, sending data to a websocket that has been closed
-    // while the app is sleeping can cause Safari to crash.  Work
-    // around this with `utils.delay`.
-    //
-    // https://bugs.webkit.org/show_bug.cgi?id=81517
-    // http://openradar.appspot.com/10811789
-    utils.delay(_send);
-  } else {
-    _send();
-  }
+    if (/iPhone|iPad|iPod/.test(navigator.userAgent) &&
+        /OS 5_0|OS 5_1/.test(navigator.userAgent)) {
+        // On iOS 5.x, sending data to a websocket that has been closed
+        // while the app is sleeping can cause Safari to crash.  Work
+        // around this with `utils.delay`.
+        //
+        // https://bugs.webkit.org/show_bug.cgi?id=81517
+        // http://openradar.appspot.com/10811789
+        utils.delay(_send);
+    } else {
+        _send();
+    }
 };
 
 WebSocketTransport.prototype.doCleanup = function() {


### PR DESCRIPTION
Repro steps here: https://gist.github.com/mloughran/2052006
