### PR TITLE
Don't use the AMD define variant that names the module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,5 +33,5 @@ if ('_sockjs_onload' in window) setTimeout(_sockjs_onload, 1);
 
 // AMD compliance
 if (typeof define === 'function' && define.amd) {
-    define('sockjs', [], function(){return SockJS;});
+    define(function(){return SockJS;});
 }


### PR DESCRIPTION
It's discouraged by http://requirejs.org/docs/api.html#modulename

Currently users need to put socks.js at the root of their project or use a paths setting.
