### PR TITLE
Fix handling of listeners added and removed mid-dispatch

### DIFF
--- a/lib/reventtarget.js
+++ b/lib/reventtarget.js
@@ -9,15 +9,6 @@
 /* Simplified implementation of DOM2 EventTarget.
  *   http://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventTarget
  */
-
-var indexOfListener = function(list, listener) {
-    for (var i = 0; i < list.length; i++) {
-        if (list[i].listener === listener)
-            return i;
-    }
-    return -1;
-};
-
 var REventTarget = function() {};
 REventTarget.prototype.addEventListener = function (eventType, listener) {
     if(!this._listeners) {
@@ -27,9 +18,11 @@ REventTarget.prototype.addEventListener = function (eventType, listener) {
         this._listeners[eventType] = [];
     }
     var arr = this._listeners[eventType];
-    if(indexOfListener(arr, listener) === -1) {
-        arr.push({listener: listener, doomed: false});
+    if(utils.arrIndexOf(arr, listener) === -1) {
+        // Make a copy so as not to interfere with a current dispatchEvent.
+        arr = arr.concat([listener]);
     }
+    this._listeners[eventType] = arr;
     return;
 };
 
@@ -38,13 +31,11 @@ REventTarget.prototype.removeEventListener = function (eventType, listener) {
         return;
     }
     var arr = this._listeners[eventType];
-    var idx = indexOfListener(arr, listener);
+    var idx = utils.arrIndexOf(arr, listener);
     if (idx !== -1) {
-        // Removing an event listener that has not yet run
-        // mid-dispatch causes the listener to not run.
-        arr[idx].doomed = true;
         if(arr.length > 1) {
-            arr.splice(idx, 1);
+            // Make a copy so as not to interfer with a current dispatchEvent.
+            this._listeners[eventType] = arr.slice(0, idx).concat( arr.slice(idx+1) );
         } else {
             delete this._listeners[eventType];
         }
@@ -64,12 +55,11 @@ REventTarget.prototype.dispatchEvent = function (event) {
         this['on'+t].apply(this, args);
     }
     if (this._listeners && t in this._listeners) {
-        // Make a copy of the listeners list; listeners added
-        // mid-dispatch should NOT run.
-        var listeners = this._listeners[t].slice(0);
+        // Grab a reference to the listeners list. removeEventListener may
+        // remove the list.
+        var listeners = this._listeners[t];
         for(var i=0; i < listeners.length; i++) {
-            if (!listeners[i].doomed)
-                listeners[i].listener.apply(this, args);
+            listeners[i].apply(this, args);
         }
     }
 };


### PR DESCRIPTION
Before, having the last event listener remove itself (to implement
EventEmitter.prototype.once-like semantics) threw an exception. Fix this by
making a copy of the listener list on dispatch. While we're at it, mimic the
semantics of the real DOM EventTarget interface. Event listeners added
mid-dispatch do not run until the next one, however listeners removed, if they
have not yet run, will not run in the current one.

Also adds a unit test to test this behavior.
