### PR TITLE
Add cachebusting parameter to /sockjs/info requests.

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -16,7 +16,11 @@ InfoReceiver.prototype = new EventEmitter(['finish']);
 InfoReceiver.prototype.doXhr = function(base_url, AjaxObject) {
     var that = this;
     var t0 = (new Date()).getTime();
-    var xo = new AjaxObject('GET', base_url + '/info');
+    var xo = new AjaxObject(
+      // add cachebusting parameter to url to work around a chrome bug:
+      // https://code.google.com/p/chromium/issues/detail?id=263981
+      // or misbehaving proxies.
+      'GET', base_url + '/info?cb=' + utils.random_string(10));
 
     var tref = utils.delay(8000,
                            function(){xo.ontimeout();});


### PR DESCRIPTION
Not sure if this is the best approach, but it fixes our immediate problem.

To replicate the behavior yourself, use Chrome load a SockJS app that has a relatively high latency (eg, deploy to a server far away, or use cell phone connection, or add artificial delay in your server with setTimeout), then hit reload a lot. The timing is a little finicky, you're aiming to hit reload sometime after the sockjs info request has started but before it has received a response from the server. If you hit reload at the right time, the tab is now 'poisoned' and will never establish a sockjs connection to the server. New tabs are fine. Clearing the browser cache or restarting the browser also fixes it.

This patch adds a random cachebusting url parameter to the /info request. I believe all the other requests that sockjs makes have already some sort of random string in them.
