### PR TITLE
Fixed duplicate variable.

### DIFF
--- a/lib/dom2.js
+++ b/lib/dom2.js
@@ -59,7 +59,7 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
                 try {
                     var status = x.status;
                     var text = x.responseText;
-                } catch (x) {};
+                } catch (e) {};
                 // IE returns 1223 for 204: http://bugs.jquery.com/ticket/1450
                 if (status === 1223) status = 204;
 


### PR DESCRIPTION
Google Closure compiler refused to process the file since 'x' was already defined above. Renamed to 'e' instead.
