### PR TITLE
Fix for Opera when dealing with an empty/error response

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -26,7 +26,13 @@ InfoReceiver.prototype.doXhr = function(base_url, AjaxObject) {
         tref = null;
         if (status === 200) {
             var rtt = (new Date()).getTime() - t0;
-            var info = JSON.parse(text);
+            var info;
+            try {
+                info = JSON.parse(text);
+            } catch (e) {
+                that.emit('finish');
+                return;
+            }
             if (typeof info !== 'object') info = {};
             that.emit('finish', info, rtt);
         } else {


### PR DESCRIPTION
This should account for the JSON parser throwing an error when dealing with a partial/empty/error response, which crashes SockJS in Opera.
