### PR TITLE
Use optimist rather than optparse-js for parsing command line arguments.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,15 @@ build: sockjs.js sockjs.min.js
 
 sockjs.js: lib/*js version
 	@$(COFFEE) -v > /dev/null
-	$(COFFEE) bin/render.coffee --set-version $(VER) lib/all.js > $@
+	$(COFFEE) bin/render.coffee --set-version "$(VER)" lib/all.js > $@
 
 sockjs.min.js: lib/*js version
 	@$(COFFEE) -v > /dev/null
-	$(COFFEE) bin/render.coffee --set-version $(VER) --minify lib/all.js > $@
+	$(COFFEE) bin/render.coffee --set-version "$(VER)" --minify lib/all.js > $@
 
 sockjs.pretty.js: lib/*js version
 	@$(COFFEE) -v > /dev/null
-	$(COFFEE) bin/render.coffee --set-version $(VER) --minify --pretty lib/all.js > $@
+	$(COFFEE) bin/render.coffee --set-version "$(VER)" --minify --pretty lib/all.js > $@
 
 tests/html/lib/sockjs.js: sockjs.js
 	cp $< $@

--- a/bin/render.coffee
+++ b/bin/render.coffee
@@ -9,7 +9,7 @@
 
 fs = require('fs')
 uglify = require('uglify-js')
-optparse = require('optparse')
+optimist = require('optimist')
 
 array_flatten = (arr, acc) ->
     if typeof acc is 'undefined'
@@ -86,20 +86,34 @@ render = (filename, depth, options) ->
 
 
 main = ->
-    switches = [
-        ['-p', '--pretty', 'Prettify javascript']
-        ['-m', '--minify', 'Minify javascript']
-        ['-s', '--set-version [VERSION]', 'Set the value of version tag']
-    ]
-    options = {minify: false, toplevel: true, version: 'unknown'}
-    parser = new optparse.OptionParser(switches)
-    parser.on 'pretty', ->
-                   options.beautify = true
-    parser.on 'minify', ->
-                   options.minify = true
-    parser.on 'set-version', (_, version) ->
-                   options.version = version
-    filenames = parser.parse((process.ARGV || process.argv).slice(2))
+    argv = optimist.options({
+        'c': {
+            alias: 'comment',
+            default: false,
+            describe: 'Add comments',
+        },
+        'm': {
+            alias: 'minify',
+            default: true,
+            describe: 'Minify javascript',
+        },
+        'p': {
+            alias: 'pretty',
+            default: true,
+            describe: 'Prettify javascript',
+        },
+        's': {
+            alias: 'set-version',
+            default: 'unknown',
+            describe: 'Set the value of version tag',
+        }})
+        .boolean('c')
+        .boolean('m')
+        .boolean('p')
+        .string('s')
+        .argv
+    options = {comment: argv.comment, minify: argv.minify, pretty: argv.pretty, toplevel: true, version: (argv.s || "unknown")}
+    filenames = argv._
 
     content = for filename in filenames
         render(filename, '', options)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "devDependencies": {
         "uglify-js"     : "1.2.5",
         "coffee-script" : "1.2.x",
-        "optparse"      : "1.0.3",
+        "optimist"      : "0.3.5",
         "node-static"   : "0.5.9"
     },
     "private": true


### PR DESCRIPTION
optimist is much more wide-spread, so this eliminates an extra
dependency for most people.
