### PR TITLE
Add the ready state constants to the SockJS prototype

### DIFF
--- a/lib/sockjs.js
+++ b/lib/sockjs.js
@@ -65,10 +65,10 @@ SockJS.prototype = new REventTarget();
 
 SockJS.version = "<!-- version -->";
 
-SockJS.CONNECTING = 0;
-SockJS.OPEN = 1;
-SockJS.CLOSING = 2;
-SockJS.CLOSED = 3;
+SockJS.prototype.CONNECTING = SockJS.CONNECTING = 0;
+SockJS.prototype.OPEN = SockJS.OPEN = 1;
+SockJS.prototype.CLOSING = SockJS.CLOSING = 2;
+SockJS.prototype.CLOSED = SockJS.CLOSED = 3;
 
 SockJS.prototype._debug = function() {
     if (this._options.debug)


### PR DESCRIPTION
Adding the ready state constants to the prototype makes the api a bit closer to the WebSocket api specs.
Having them on the prototype also allows other applications / libraries to avoid an explicit SockJS dependency.
