### PR TITLE
fixes sockjs-node link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ QUnit tests and smoke tests
 ---------------------------
 
 SockJS comes with some QUnit tests and a few smoke tests (using
-[SockJS-node](https://github.com/sockjs/sockjs-client) on the server
+[SockJS-node](https://github.com/sockjs/sockjs-node) on the server
 side).
 
 Example


### PR DESCRIPTION
There is a link to SockJS-node in the readme, but it links to this repository instead of the node one, so I fixed it real quick.
