### PR TITLE
Fix #79, avoid using XDRObject when connecting across schemes

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -93,14 +93,18 @@ var createInfoReceiver = function(base_url) {
         // XHRLocalObject -> no_credentials=true
         return new InfoReceiver(base_url, utils.XHRLocalObject);
     case 2:
-        return new InfoReceiver(base_url, utils.XDRObject);
+        // IE 8/9 if the request target uses the same scheme
+        if (utils.isSameOriginScheme(base_url)) {
+            return new InfoReceiver(base_url, utils.XDRObject);
+        }
+        break;
     case 3:
         // Opera
         return new InfoReceiverIframe(base_url);
-    default:
-        // IE 7
-        return new InfoReceiverFake();
     };
+
+    // IE 7, and IE 8/9 if requesting across schemes (e.g. http -> https)
+    return new InfoReceiverFake();
 };
 
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,6 +40,12 @@ utils.isSameOriginUrl = function(url_a, url_b) {
             url_b.split('/').slice(0,3).join('/'));
 };
 
+utils.isSameOriginScheme = function(url_a, url_b) {
+    if (!url_b) url_b = _window.location.href;
+
+    return (url_a.split(':')[0] === url_b.split(':')[0]);
+};
+
 utils.getParentDomain = function(url) {
     // ipv4 ip address
     if (/^[0-9.]*$/.test(url)) return url;


### PR DESCRIPTION
This is a PR in reference to https://github.com/sockjs/sockjs-client/issues/79

Currently, IE8 and IE9 can't connect from http to a SockJS server using SSL. This is due to XDRObjects enforcing that requests use the same scheme as the hosting page. Simply excluding `xdr-streaming` and `xdr-polling` from the `protocols_whitelist` doesn't work since IE8/9 will always use an XDRObject when creating an InfoReceiver.

I understand that forcing the client to use `jsonp-polling` as the default transport in this case might not be ideal. As @majek hinted to in the comment thread, someone might want to avoid supporting http -> https. However, I think it would be nice to have the option, since it's supported with all other browsers and transports. And with this PR, a user could handle this behaviour by simply editing the protocols_whitelist, e.g.

``` js
var options = {};

if (location.protocol === 'http:') {
    // Enable http->https requests in IE8/9 by excluding xdr streaming/polling
    options.protocols_whitelist = ['websocket', 'xhr-streaming',
        'iframe-eventsource', 'iframe-htmlfile', 'xhr-polling',
        'iframe-xhr-polling', 'jsonp-polling'];
}

var sockjs = new SockJS(url, null, options);
```

Thanks!
