### PR TITLE
Remove ESC problem of firefox from browser quirks

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,6 @@ Browser Quirks
 
 There are various browser quirks which we don't intend to address:
 
- * Pressing ESC in Firefox closes SockJS connection. For a workaround
-   and discussion see [#18](https://github.com/sockjs/sockjs-client/issues/18).
  * Jsonp-polling transport will show a "spinning wheel" (aka. "busy indicator")
    when sending data.
  * You can't open more than one SockJS connection to one domain at the


### PR DESCRIPTION
As the ticket that was linked states this has been fixed in FF and should thus no longer be listed here, I think.
