### PR TITLE
Slightly increase the value of the retransmission timeout

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,14 +86,15 @@ utils.userSetCode = function (code) {
 // See: http://www.erg.abdn.ac.uk/~gerrit/dccp/notes/ccid2/rto_estimator/
 // and RFC 2988.
 utils.countRTO = function (rtt) {
-    var rto;
-    if (rtt > 100) {
-        rto = 3 * rtt; // rto > 300msec
-    } else {
-        rto = rtt + 200; // 200msec < rto <= 300msec
-    }
-    return rto;
-}
+    // In a local environment, when using IE8/9 and the `jsonp-polling`
+    // transport the time needed to establish a connection (the time that pass
+    // from the opening of the transport to the call of `_dispatchOpen`) is
+    // around 200msec (the lower bound used in the article above) and this
+    // causes spurious timeouts. For this reason we calculate a value slightly
+    // larger than that used in the article.
+    if (rtt > 100) return 4 * rtt; // rto > 400msec
+    return 300 + rtt;              // 300msec < rto <= 400msec
+};
 
 utils.log = function() {
     if (_window.console && console.log && console.log.apply) {


### PR DESCRIPTION
This fixes an issue with IE8/9 when using the `jsonp-polling` transport.

If the round trip time is very low the computed retransmission timeout is too low for IE8/9 and the connection fails.

In this gist https://gist.github.com/lpinca/9760159 i put a simple test case to reproduce the issue.
When the connection fails the close event shows the following info:

```
LOG: SimpleEvent(
  type=close,
  code=2000,
  reason=All transports failed,
  wasClean=false,
  last_event=SimpleEvent(type=close, code=2007, reason=Transport timeouted, wasClean=false)
)
```

Increasing the `rto` lower bound by a few milliseconds fixes the issue.
