### PR TITLE
Remove test for iframe.contentWindow

### DIFF
--- a/lib/trans-iframe.js
+++ b/lib/trans-iframe.js
@@ -45,9 +45,7 @@ IframeTransport.prototype.doCleanup = function() {
         try {
             // When the iframe is not loaded, IE raises an exception
             // on 'contentWindow'.
-            if (that.iframeObj.iframe.contentWindow) {
-                that.postMessage('c');
-            }
+            that.postMessage('c');
         } catch (x) {}
         that.iframeObj.cleanup();
         that.iframeObj = null;


### PR DESCRIPTION
Remove the check for that.iframeObj.iframe.contentWindow before call postMessage; the utils.createIframe does not return a reference to the iframe (reference removed in change #55 to dom.js) so this check always fails and no close message is ever sent.

The post method set up in utils.createIframe already tests for iframe.contentWindow so this approach seems safe.
