### PR TITLE
Galaxy S4 cannot post cross domain message over HTTPS with XHR protocol

### DIFF
--- a/lib/trans-sender.js
+++ b/lib/trans-sender.js
@@ -128,7 +128,9 @@ var jsonPGenericSender = function(url, payload, callback) {
 
 var createAjaxSender = function(AjaxObject) {
     return function(url, payload, callback) {
-        var xo = new AjaxObject('POST', url + '/xhr_send', payload);
+        var opt = {};
+        if (typeof payload === 'string') opt.headers = {'Content-type':'text/plain'};
+        var xo = new AjaxObject('POST', url + '/xhr_send', payload, opt);
         xo.onfinish = function(status, text) {
             callback(status === 200 || status === 204,
                      'http status ' + status);


### PR DESCRIPTION
I found that, Galaxy S4 (Android 4.3) browser can not make cross domain HTTPS XMLHttpRequest with body, if `Content-Type` request header was not set. This PR fixes it.

---

More info:

I think the default browser of Galaxy S4 (Android 4.3) supports WebSocket, but in my case, some devices fallback to XHR.

When it uses XHR protocol, it always fails to post message `xhr.send(payload)` to cross domain server over HTTPS.

The request is terminated by the browser. Error `http status 0` is returned.

For more detail, see: https://github.com/georgeOsdDev/sockjs_cross_domain
