### PR TITLE
Fix iframe fallback when the message is sent from a popup in IE

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -126,7 +126,9 @@ utils.createIframe = function (iframe_url, error_callback) {
             // When the iframe is not loaded, IE raises an exception
             // on 'contentWindow'.
             if (iframe && iframe.contentWindow) {
-                iframe.contentWindow.postMessage(msg, origin);
+                setTimeout(function() {
+                    iframe.contentWindow.postMessage(msg, origin);
+                }, 0);
             }
         } catch (x) {};
     };
@@ -178,7 +180,9 @@ utils.createHtmlfile = function (iframe_url, error_callback) {
             // When the iframe is not loaded, IE raises an exception
             // on 'contentWindow'.
             if (iframe && iframe.contentWindow) {
-                iframe.contentWindow.postMessage(msg, origin);
+                setTimeout(function() {
+                    iframe.contentWindow.postMessage(msg, origin);
+                }, 0);
             }
         } catch (x) {};
     };

--- a/tests/html/sockjs-in-parent.html
+++ b/tests/html/sockjs-in-parent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <script>
+    document.domain = document.domain;
+  </script>
+  <script>
+    c = parent._sockjs_global;
+    window_id = document.location.hash.slice(1);
+    hook = c(window_id);
+    hook.callback = function(code) {eval(code);};
+    hook.open();
+  </script>
+</head>
+<body>
+  <h2>Don't panic!</h2>
+</body>


### PR DESCRIPTION
In Internet Explorer an "Operation Aborted" error will throw when an opened window is trying to call a function on a parent which this one will do a `postMessage` (the error is silent due to the `catch (x) {}`).

Requeuing the `postMessage` at the end of the execution queue with a `setTimeout(0)` fix the problem ([source](http://stackoverflow.com/questions/9703730/does-html5-support-cross-window-messaging#comment18932554_9706518)).
