### PR TITLE
Add missing onerror listener for WebSockets

### DIFF
--- a/lib/trans-websocket.js
+++ b/lib/trans-websocket.js
@@ -29,7 +29,7 @@ var WebSocketTransport = SockJS.websocket = function(ri, trans_url) {
     // https://github.com/sockjs/sockjs-client/issues/28
     // https://bugzilla.mozilla.org/show_bug.cgi?id=696085
     that.unload_ref = utils.unload_add(function(){that.ws.close()});
-    that.ws.onclose = function() {
+    that.ws.onclose = that.ws.onerror = function() {
         that.ri._didMessage(utils.closeFrame(1006, "WebSocket connection broken"));
     };
 };
@@ -42,7 +42,7 @@ WebSocketTransport.prototype.doCleanup = function() {
     var that = this;
     var ws = that.ws;
     if (ws) {
-        ws.onmessage = ws.onclose = null;
+        ws.onmessage = ws.onclose = ws.onerror = null;
         ws.close();
         utils.unload_del(that.unload_ref);
         that.unload_ref = that.ri = that.ws = null;


### PR DESCRIPTION
This adds a listener to be called when an error occurs.
