### PR TITLE
Enable withCredentials flag also for requests sent to /info

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -96,8 +96,7 @@ var createInfoReceiver = function(base_url) {
     }
     switch (utils.isXHRCorsCapable()) {
     case 1:
-        // XHRLocalObject -> no_credentials=true
-        return new InfoReceiver(base_url, utils.XHRLocalObject);
+        return new InfoReceiver(base_url, utils.XHRCorsObject);
     case 2:
         // IE 8/9 if the request target uses the same scheme
         if (utils.isSameOriginScheme(base_url)) {


### PR DESCRIPTION
It could be useful to have access to cookies and authorization headers also for cross-site requests sent to /info, for example when using an authorization middleware.

This is what the patch does.
