### PR TITLE
open SockJS connection event document ready state is "interactive"

### DIFF
--- a/lib/sockjs.js
+++ b/lib/sockjs.js
@@ -192,7 +192,8 @@ SockJS.prototype._try_next_protocol = function(close_event) {
             SockJS[protocol].need_body === true &&
             (!_document.body ||
              (typeof _document.readyState !== 'undefined'
-              && _document.readyState !== 'complete'))) {
+              && _document.readyState !== 'complete'
+              && _document.readyState !== 'interactive'))) {
             that._protocols.unshift(protocol);
             that.protocol = 'waiting-for-load';
             utils.attachEvent('load', function(){


### PR DESCRIPTION
Some of SockJS transports need `document.body` availability, so there is a test of [`document.readyState`](https://developer.mozilla.org/en-US/docs/Web/API/document.readyState) to be `complete`. But there is one more state means body of document has been loaded and available - `interactive`. 

Why we must test `document.readyState` to be `complete` or `interactive` not only `complete`? 

Just because old versions of Opera browser (10.62 for example) switch `document.readyState` to `interactive` after iframe has been inserted into the DOM, and never switch to `complete` state back. This is only one reason SockJS does not work with Opera <10.70.
