### PR TITLE
WP8 throws an exception when files are accessed from file system.

### DIFF
--- a/lib/sockjs.js
+++ b/lib/sockjs.js
@@ -260,7 +260,13 @@ SockJS.prototype._applyInfo = function(info, rtt, protocols_whitelist) {
     that._rtt = rtt;
     that._rto = utils.countRTO(rtt);
 
-    info.null_origin = !document.domain;
+    // WP8 throws an exception when files are accessed from file system (file://)
+    try {
+      info.null_origin = !document.domain;
+    } catch(e) {
+      info.null_origin = null;
+    }
+    
     // Servers can override base_url, eg to provide a randomized domain name and
     // avoid browser per-domain connection limits.
     if (info.base_url)


### PR DESCRIPTION
WP8 "document.domain" throws an exception when files are accessed from file system (file://).
