### PR TITLE
Use `window.location` instead of `document.location`

### DIFF
--- a/lib/sockjs.js
+++ b/lib/sockjs.js
@@ -213,7 +213,7 @@ SockJS.prototype._try_next_protocol = function(close_event) {
             utils.attachEvent('load', tryNextProtocol);
             return true;
         }
-        
+
         var roundTrips = Protocol.roundTrips || 1;
         var to = ((that._rto || 0) * roundTrips) || 5000;
         that._transport_tref = setTimeout(timeoutFunction, to);
@@ -266,7 +266,7 @@ utils.parent_origin = undefined;
 
 SockJS.bootstrap_iframe = function() {
     var facade;
-    utils.curr_window_id = document.location.hash.slice(1);
+    utils.curr_window_id = window.location.hash.slice(1);
     var onMessage = function(e) {
         if(e.source !== parent) return;
         if(typeof utils.parent_origin === 'undefined')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -153,7 +153,7 @@ utils.flatUrl = function(url) {
 };
 
 utils.amendUrl = function(url) {
-    var dl = document.location;
+    var dl = window.location;
     if (!url) {
         throw new Error('Wrong url for SockJS');
     }

--- a/tests/html/iframe.html
+++ b/tests/html/iframe.html
@@ -12,7 +12,7 @@
   <h2>Don't panic!</h2>
   <script>
     c = parent._sockjs_global;
-    window_id = document.location.hash.slice(1);
+    window_id = window.location.hash.slice(1);
     hook = c(window_id);
     hook.callback = function(code) {eval(code);};
     hook.open();

--- a/tests/html/lib/endtoendtests.js
+++ b/tests/html/lib/endtoendtests.js
@@ -42,7 +42,7 @@ test("invalid url port", function(done) {
   this.runnable().globals(['_sockjs_global']);
   var dl, r;
   //expect(4);
-  dl = document.location;
+  dl = window.location;
   r = testutils.newSockJS(dl.protocol + '//' + dl.hostname + ':1079', 'jsonp-polling');
   assert.ok(r);
   r.onopen = function(e) {

--- a/tests/html/lib/unittests.js
+++ b/tests/html/lib/unittests.js
@@ -110,7 +110,7 @@ test('bind', function() {
 
 test('amendUrl', function() {
   var dl, t;
-  dl = document.location;
+  dl = window.location;
   assert.equal(u.amendUrl('//blah:1/abc'), dl.protocol + '//blah:1/abc');
   assert.equal(u.amendUrl('/abc'), dl.protocol + '//' + dl.host + '/abc');
   assert.equal(u.amendUrl('/'), dl.protocol + '//' + dl.host);

--- a/tests/html/sockjs-in-head.html
+++ b/tests/html/sockjs-in-head.html
@@ -9,7 +9,7 @@
   <script src="/lib/sockjs.js?no=cache"></script>
   <script>
     c = parent._sockjs_global;
-    window_id = document.location.hash.slice(1);
+    window_id = window.location.hash.slice(1);
     hook = c(window_id);
     hook.callback = function(code) {eval(code);};
     hook.open();

--- a/tests/html/sockjs-in-parent.html
+++ b/tests/html/sockjs-in-parent.html
@@ -8,7 +8,7 @@
   </script>
   <script>
     c = parent._sockjs_global;
-    window_id = document.location.hash.slice(1);
+    window_id = window.location.hash.slice(1);
     hook = c(window_id);
     hook.callback = function(code) {eval(code);};
     hook.open();


### PR DESCRIPTION
If a frame, image, or form is named "location" then document.location
will refer to that element instead of being an alias for `window.location`
see https://github.com/meteor/meteor/issues/2380 cc @glasser 
