### PR TITLE
Add Atmosphere Framework as a framework supporting Sockjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ SockJS family:
   * [Spring Framework](http://projects.spring.io/spring-framework) Java server
   * [vert.x](https://github.com/vert-x/vert.x) Java/vert.x server
   * [Xitrum](http://xitrum-framework.github.io/) Scala server
+  * [Atmosphere Framework](http://github.com/Atmosphere/atmosphere) JavaEE Server, Play Framework, Netty, Vert.x
 
 Work in progress:
 


### PR DESCRIPTION
Add the Atmosphere Framework's as a framework supporting Sockjs on the JVM =>  [https://github.com/Atmosphere/atmosphere-extensions/tree/master/sockjs/modules/src/main/java/org/atmosphere/sockjs]
