### PR TITLE
Move debug from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     }
   ],
   "dependencies": {
+    "debug": "^2.1.0",
     "eventsource": "^0.1.3",
     "faye-websocket": "~0.7.3",
     "inherits": "^2.0.1",
@@ -32,7 +33,6 @@
   },
   "devDependencies": {
     "browserify": "^6.1.0",
-    "debug": "^2.1.0",
     "envify": "~3.0.0",
     "expect.js": "~0.3.1",
     "gulp": "^3.8.8",


### PR DESCRIPTION
The client does not work when used in node:

``` shell
macbook:debug luigi$ npm i sockjs/sockjs-client
sockjs-client@1.0.0-beta.2 node_modules/sockjs-client
├── inherits@2.0.1
├── url-parse@0.0.4
├── json3@3.3.2
├── eventsource@0.1.4 (original@0.0.5)
└── faye-websocket@0.7.3 (websocket-driver@0.3.6)
macbook:debug luigi$ node
> var sockjs = require('sockjs-client');
Error: Cannot find module 'debug'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/luigi/Desktop/debug/node_modules/sockjs-client/lib/utils/url.js:7:11)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```

If the intended method is to require the browserify bundle under the `/dist`, just close this pr.
