### PR TITLE
Don't remove basic authentication credentials

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -90,8 +90,14 @@ function SockJS(url, protocols, options) {
   // remove the trailing slash
   parsedUrl.path = parsedUrl.pathname.replace(/[/]+$/, '') + (parsedUrl.query || '');
 
+  // basic authentication
+  parsedUrl.auth = parsedUrl.username
+    ? parsedUrl.username + ':' + parsedUrl.password + '@'
+    : '';
+
   // store the sanitized url
-  this.url = parsedUrl.protocol + '//' + parsedUrl.hostname + (parsedUrl.port ? (':' + parsedUrl.port) : '') + parsedUrl.path;
+  this.url = parsedUrl.protocol + '//' + parsedUrl.auth + parsedUrl.hostname +
+    (parsedUrl.port ? ':' + parsedUrl.port : '') + parsedUrl.path;
   debug('using url', this.url);
 
   // Step 7 - start connection in background

--- a/tests/lib/main.js
+++ b/tests/lib/main.js
@@ -23,6 +23,12 @@ describe('SockJS', function() {
       s.close();
     });
 
+    it('should not remove basic authentication credentials', function () {
+      var s = new SockJS('http://user:password@localhost');
+      expect(s).to.have.property('url', 'http://user:password@localhost');
+      s.close();
+    });
+
     describe('WebSocket specification step #1', function () {
       it('should throw SyntaxError for an invalid url', function () {
         expect(function () {
@@ -32,7 +38,7 @@ describe('SockJS', function() {
         });
       });
 
-      it('should throw TypeError for an null url', function () {
+      it('should throw TypeError for a null url', function () {
         expect(function () {
           new SockJS();
         }).to.throwException(function (e) {
@@ -41,7 +47,7 @@ describe('SockJS', function() {
       });
 
       it('should throw SyntaxError when the url contains a fragment', function () {
-         expect(function () {
+        expect(function () {
           new SockJS('http://localhost/#test');
         }).to.throwException(function (e) {
           expect(e).to.be.a(SyntaxError);


### PR DESCRIPTION
This fixes an issue where basic authentication credentials were not included in the sanitized URL.
