### PR TITLE
Use the `auth` property of the parsed URL

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -94,14 +94,9 @@ function SockJS(url, protocols, options) {
   // remove the trailing slash
   parsedUrl.path = parsedUrl.pathname.replace(/[/]+$/, '') + (parsedUrl.query || '');
 
-  // basic authentication
-  parsedUrl.auth = parsedUrl.username
-    ? parsedUrl.username + ':' + parsedUrl.password + '@'
-    : '';
-
   // store the sanitized url
-  this.url = parsedUrl.protocol + '//' + parsedUrl.auth + parsedUrl.hostname +
-    (parsedUrl.port ? ':' + parsedUrl.port : '') + parsedUrl.path;
+  this.url = parsedUrl.protocol + '//' + (parsedUrl.auth ? parsedUrl.auth + '@' : '') +
+    parsedUrl.hostname + (parsedUrl.port ? ':' + parsedUrl.port : '') + parsedUrl.path;
   debug('using url', this.url);
 
   // Step 7 - start connection in background

--- a/tests/lib/main.js
+++ b/tests/lib/main.js
@@ -23,7 +23,13 @@ describe('SockJS', function() {
       s.close();
     });
 
-    it('should not remove basic authentication credentials', function () {
+    it('should not remove basic authentication credentials (1/2)', function () {
+      var s = new SockJS('http://user@localhost');
+      expect(s).to.have.property('url', 'http://user@localhost');
+      s.close();
+    });
+
+    it('should not remove basic authentication credentials (2/2)', function () {
       var s = new SockJS('http://user:password@localhost');
       expect(s).to.have.property('url', 'http://user:password@localhost');
       s.close();


### PR DESCRIPTION
There is no need to set the `auth` property in the parsed URL, becuase the `url-parse` module parses it correctly.