### PR TITLE
Add support for IPv6 literal addresses in the connection URL

### DIFF
--- a/lib/transport/driver/xhr.js
+++ b/lib/transport/driver/xhr.js
@@ -19,7 +19,7 @@ function XhrDriver(method, url, payload, opts) {
   var parsedUrl = new URL(url);
   var options = {
     method: method
-  , hostname: parsedUrl.hostname
+  , hostname: parsedUrl.hostname.replace(/\[|\]/g, '')
   , port: parsedUrl.port
   , path: parsedUrl.pathname + (parsedUrl.query || '')
   , headers: opts && opts.headers

--- a/tests/lib/test-utils.js
+++ b/tests/lib/test-utils.js
@@ -13,7 +13,9 @@ module.exports = {
     if (global.location) {
       return urlUtils.getOrigin(global.location.href);
     }
-    return 'http://localhost:8081';
+    return /^v0\.(?:8|10)/.test(process.version)
+      ? 'http://localhost:8081'
+      : 'http://[::1]:8081';
   }
 
 , getCrossOriginUrl: function () {


### PR DESCRIPTION
When a literal IPv6 address is used in the connection URL, the `url-parse` module parses the `hostname` including the square brackets:
```js
> var parse = require('url-parse');
undefined
>  parse('http://[::1]:8081');
{ hash: '',
  query: '',
  protocol: 'http:',
  pathname: '',
  auth: '',
  host: '[::1]:8081',
  port: '8081',
  hostname: '[::1]',
  password: '',
  username: '',
  href: 'http://[::1]:8081' }
```
This works fine in the browsers, but in node the `http.request` used by the `XhrDriver` needs a `hostname` without square brackets.