### PR TITLE
Simplify the URL sanitization

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -92,11 +92,10 @@ function SockJS(url, protocols, options) {
   this._origin = o ? o.toLowerCase() : null;
 
   // remove the trailing slash
-  parsedUrl.path = parsedUrl.pathname.replace(/[/]+$/, '') + (parsedUrl.query || '');
+  parsedUrl.set('pathname', parsedUrl.pathname.replace(/\/+$/, ''));
 
   // store the sanitized url
-  this.url = parsedUrl.protocol + '//' + (parsedUrl.auth ? parsedUrl.auth + '@' : '') +
-    parsedUrl.hostname + (parsedUrl.port ? ':' + parsedUrl.port : '') + parsedUrl.path;
+  this.url = parsedUrl.href;
   debug('using url', this.url);
 
   // Step 7 - start connection in background


### PR DESCRIPTION
This simplifies the URL sanitization by taking advantage of the `url-parse` module as suggested by @3rd-Eden here https://github.com/sockjs/sockjs-client/pull/239#issuecomment-99197750.