### PR TITLE
check for a valid iframe.contentWindow inside the timeout call

### DIFF
--- a/lib/utils/iframe.js
+++ b/lib/utils/iframe.js
@@ -74,7 +74,9 @@ module.exports = {
         // on 'contentWindow'.
         if (iframe && iframe.contentWindow) {
           setTimeout(function() {
-            iframe.contentWindow.postMessage(msg, origin);
+            if (iframe && iframe.contentWindow) {
+              iframe.contentWindow.postMessage(msg, origin);
+            }
           }, 0);
         }
       } catch (x) {}
@@ -140,7 +142,9 @@ module.exports = {
         // on 'contentWindow'.
         if (iframe && iframe.contentWindow) {
           setTimeout(function() {
-            iframe.contentWindow.postMessage(msg, origin);
+            if (iframe && iframe.contentWindow) {
+              iframe.contentWindow.postMessage(msg, origin);
+            }
           }, 0);
         }
       } catch (x) {}


### PR DESCRIPTION
address a possible race condition where the call to the iframe's postMessage can happen after the frame has been closed.  The initial check can succeed, but the call happens 'later' and it is possible for the frame to be closed.