### PR TITLE
Allow custom session ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ Where `options` is a hash which can contain:
     option allows you to supply a list transports that may be used by
     SockJS. By default all available transports will be used.
 
+ *  **sessionId (number OR function)**
+
+    Both client and server use session identifiers to distinguish connections.
+    If you specify this option as a number, SockJS will use its random string
+    generator function to generate session ids that are N-character long
+    (where N corresponds to the number specified by **sessionId**).
+    When you specify this option as a function, the function must return a
+    randomly generated string. Every time SockJS needs to generate a session
+    id it will call this function and use the returned string directly.
+    If you don't specify this option, the default is to use the default random
+    string generator to generate 8-character long session ids.
 
 Although the 'SockJS' object tries to emulate the 'WebSocket'
 behaviour, it's impossible to support all of its features. An

--- a/lib/main.js
+++ b/lib/main.js
@@ -50,6 +50,18 @@ function SockJS(url, protocols, options) {
     log.warn("'protocols_whitelist' is DEPRECATED. Use 'transports' instead.");
   }
   this._transportsWhitelist = options.transports;
+
+  var sessionId = options.sessionId || 8;
+  if (typeof sessionId === 'function') {
+    this._generateSessionId = sessionId;
+  } else if (typeof sessionId === 'number') {
+    this._generateSessionId = function() {
+      return random.string(sessionId);
+    }
+  } else {
+    throw new TypeError("If sessionId is used in the options, it needs to be a number or a function.");
+  }
+
   this._server = options.server || random.numberString(1000);
 
   // Step 1 of WS spec - parse and validate the url. Issue #8
@@ -202,7 +214,7 @@ SockJS.prototype._connect = function() {
     this._transportTimeoutId = setTimeout(this._transportTimeout.bind(this), timeoutMs);
     debug('using timeout', timeoutMs);
 
-    var transportUrl = urlUtils.addPath(this._transUrl, '/' + this._server + '/' + random.string(8));
+    var transportUrl = urlUtils.addPath(this._transUrl, '/' + this._server + '/' + this._generateSessionId());
     debug('transport url', transportUrl);
     var transportObj = new Transport(transportUrl, this._transUrl);
     transportObj.on('message', this._transportMessage.bind(this));

--- a/tests/lib/main.js
+++ b/tests/lib/main.js
@@ -70,5 +70,36 @@ describe('SockJS', function() {
         });
       });
     });
+
+    it('should generate 8-character-long session ids by default', function () {
+      var s = SockJS('http://localhost');
+      expect(s._generateSessionId().length).to.be(8);
+      s.close();
+    });
+
+    it('should generate N-character-long session ids', function () {
+      for (var i = 1; i <= 100; i++) {
+        var s = SockJS('http://localhost', null, {sessionId: i});
+        expect(s._generateSessionId().length).to.be(i);
+        s.close();
+      }
+    });
+
+    it('should generate sessionIds using the custom generator function', function () {
+      var f = function() {
+        return 'this_is_not_random';
+      };
+      var s = SockJS('http://localhost', null, {sessionId: f});
+      expect(s._generateSessionId).to.be(f);
+      s.close();
+    });
+
+    it('should throw TypeError if sessionId is neither a number nor a function', function () {
+        expect(function () {
+          new SockJS('http://localhost', null, {sessionId: 'this is wrong'});
+        }).to.throwException(function (e) {
+          expect(e).to.be.a(TypeError);
+        });
+    });
   });
 });


### PR DESCRIPTION
Every time a new connection is made to a sockjs server, a session id is
generated in the client and sent to the server. This session id helps
the server distinguish connections. By default, the current code
generates a random 8-character-long string as session id. There is
currently no way to increase the entropy or even generate your own
session ids, so this commit is an attempt to tackle that limitation.