### PR TITLE
Remove Array.prototype.slice for arguments for optimization

### DIFF
--- a/lib/event/emitter.js
+++ b/lib/event/emitter.js
@@ -39,7 +39,12 @@ EventEmitter.prototype.emit = function(type) {
   if (!listeners) {
     return;
   }
-  var args = Array.prototype.slice.call(arguments, 1);
+  // We need to copy arguments to local array for using it in another function call.
+  // The only way js engine (like V8) will be able to optimize it.
+  var args = [];
+  for (var ai = 1; ai < arguments.length; ++ai) {
+    args.push(arguments[ai]);
+  }
   for (var i = 0; i < listeners.length; i++) {
     listeners[i].apply(this, args);
   }

--- a/lib/event/eventtarget.js
+++ b/lib/event/eventtarget.js
@@ -39,22 +39,51 @@ EventTarget.prototype.removeEventListener = function(eventType, listener) {
 };
 
 EventTarget.prototype.dispatchEvent = function(event) {
-  var t = event.type;
-  var args = Array.prototype.slice.call(arguments, 0);
   // TODO: This doesn't match the real behavior; per spec, onfoo get
   // their place in line from the /first/ time they're set from
   // non-null. Although WebKit bumps it to the end every time it's
   // set.
-  if (this['on' + t]) {
-    this['on' + t].apply(this, args);
-  }
-  if (t in this._listeners) {
-    // Grab a reference to the listeners list. removeEventListener may alter the list.
-    var listeners = this._listeners[t];
-    for (var i = 0; i < listeners.length; i++) {
-      listeners[i].apply(this, args);
+  if (arguments.length < 2) {
+    dispatchEventSingleArg(this, event);
+  } else {
+    // We need to copy arguments to local array for using it in another function call.
+    // The only way js engine (like V8) will be able to optimize it.
+    var args = [];
+    for (var i = 0; i < arguments.length; ++i) {
+      args.push(arguments[i]);
     }
+    dispatchEventMultiArgs(this, event, args);
   }
 };
+
+function dispatchEventSingleArg(eventTarget, event) {
+  var type = event.type;
+  var typeWithOn = 'on' + type;
+  if (eventTarget[typeWithOn]) {
+    eventTarget[typeWithOn].call(eventTarget, event);
+  }
+  if (type in eventTarget._listeners) {
+    // Grab a reference to the listeners list. removeEventListener may alter the list.
+    var listeners = eventTarget._listeners[type];
+    for (var i = 0; i < listeners.length; i++) {
+      listeners[i].call(eventTarget, event);
+    }
+  }
+}
+
+function dispatchEventMultiArgs(eventTarget, event, args) {
+  var type = event.type;
+  var typeWithOn = 'on' + type;
+  if (eventTarget[typeWithOn]) {
+    eventTarget[typeWithOn].apply(eventTarget, args);
+  }
+  if (type in eventTarget._listeners) {
+    // Grab a reference to the listeners list. removeEventListener may alter the list.
+    var listeners = eventTarget._listeners[type];
+    for (var i = 0; i < listeners.length; i++) {
+      listeners[i].apply(eventTarget, args);
+    }
+  }
+}
 
 module.exports = EventTarget;


### PR DESCRIPTION
Hi, thanks for great websocket library!

There are some good topics about optimizations, for example: [Optimization-killers] (https://github.com/petkaantonov/bluebird/wiki/Optimization-killers). Functions with Array.prototype.slice.call(arguments) cannot be optimized. So I replaced them like this [commit] (https://github.com/nodejs/node-v0.x-archive/commit/91f1b250ecb4fb8151cd17423dd4460652d0ce97) in Node.js from one of V8 developer.