### PR TITLE
Bump faye-websocket to version 0.11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "debug": "^2.1.0",
     "eventsource": "^0.1.3",
-    "faye-websocket": "~0.7.3",
+    "faye-websocket": "~0.11.0",
     "inherits": "^2.0.1",
     "json3": "^3.3.2",
     "url-parse": "^1.0.1"


### PR DESCRIPTION
This updates `faye-websocket` to the latest version.