### PR TITLE
Sockjs 1.03 not running on IE8/IE7 browsers since apply method missing

### DIFF
--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -2,15 +2,15 @@
 
 var logObject = {};
 ['log', 'debug', 'warn'].forEach(function (level) {
-    var levelExists;
-    
-    try {
-        levelExists = global.console && global.console[level] && global.console[level].apply;
-    } catch(e){}
-    
-    logObject[level] = levelExists ? function () {
-    return global.console[level].apply(global.console, arguments);
-    } : (level === 'log' ? function () {} : logObject.log);
+  var levelExists;
+  
+  try {
+      levelExists = global.console && global.console[level] && global.console[level].apply;
+  } catch(e){}
+  
+  logObject[level] = levelExists ? function () {
+  return global.console[level].apply(global.console, arguments);
+  } : (level === 'log' ? function () {} : logObject.log);
 
 });
 

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -2,10 +2,15 @@
 
 var logObject = {};
 ['log', 'debug', 'warn'].forEach(function (level) {
-  var levelExists = global.console && global.console[level] && global.console[level].apply;
+    var levelExists;
+    try {
+        levelExists = global.console && global.console[level] && global.console[level].apply;
+    } catch(e){}
+
   logObject[level] = levelExists ? function () {
     return global.console[level].apply(global.console, arguments);
   } : (level === 'log' ? function () {} : logObject.log);
+
 });
 
 module.exports = logObject;

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -3,13 +3,14 @@
 var logObject = {};
 ['log', 'debug', 'warn'].forEach(function (level) {
     var levelExists;
+    
     try {
         levelExists = global.console && global.console[level] && global.console[level].apply;
     } catch(e){}
-
-  logObject[level] = levelExists ? function () {
+    
+    logObject[level] = levelExists ? function () {
     return global.console[level].apply(global.console, arguments);
-  } : (level === 'log' ? function () {} : logObject.log);
+    } : (level === 'log' ? function () {} : logObject.log);
 
 });
 


### PR DESCRIPTION
added fix for old browsers such as IE7/8 were console.log
does not have an apply function.
using try catch we are take care that everything works.
tested on IE8/IE7 via Edge (IE11).

Fixes #276 