### PR TITLE
FIX error with webpack when WebSocket not exists

### DIFF
--- a/lib/transport/browser/websocket.js
+++ b/lib/transport/browser/websocket.js
@@ -5,4 +5,6 @@ if (Driver) {
 	module.exports = function WebSocketBrowserDriver(url) {
 		return new Driver(url);
 	};
+} else {
+	module.exports = undefined;
 }


### PR DESCRIPTION
When building with webpack and you didn't define module.exports it will default to an empty object {}
So when transport.enabled test !!WebSocketDriver it returns true instead of false.
