### PR TITLE
Switch to using Emitter instead of EventTarget

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -14,7 +14,7 @@ var URL = require('url-parse')
   , browser = require('./utils/browser')
   , log = require('./utils/log')
   , Event = require('./event/event')
-  , EventTarget = require('./event/eventtarget')
+  , EventEmitter = require('./event/emitter').EventEmitter
   , loc = require('./location')
   , CloseEvent = require('./event/close')
   , TransportMessageEvent = require('./event/trans-message')
@@ -36,7 +36,7 @@ function SockJS(url, protocols, options) {
   if (arguments.length < 1) {
     throw new TypeError("Failed to construct 'SockJS: 1 argument required, but only 0 present");
   }
-  EventTarget.call(this);
+  EventEmitter.call(this);
 
   this.readyState = SockJS.CONNECTING;
   this.extensions = '';
@@ -122,7 +122,7 @@ function SockJS(url, protocols, options) {
   this._ir.once('finish', this._receiveInfo.bind(this));
 }
 
-inherits(SockJS, EventTarget);
+inherits(SockJS, EventEmitter);
 
 function userSetCode(code) {
   return code === 1000 || (code >= 3000 && code <= 4999);


### PR DESCRIPTION
The client didn't appear to provide any common *.on, *.once event listener functions. e.g:

`foo.on('message', function(data){
  console.log(data);
})`

`foo.once('open', function(){ .. })`

I noticed that add/remove listener functions are provided by inheriting from EventTarget. I also noticed that Emitter also inherits from EventTarget and provides *.on, *.once listener functions. So, I swapped out EventTarget for Emitter to provide the common listeners while also being backwards compatible.
