### PR TITLE
Remove the event listeners before calling `ws.close()`

### DIFF
--- a/lib/transport/websocket.js
+++ b/lib/transport/websocket.js
@@ -66,10 +66,11 @@ WebSocketTransport.prototype.send = function(data) {
 
 WebSocketTransport.prototype.close = function() {
   debug('close');
-  if (this.ws) {
-    this.ws.close();
-  }
+  var ws = this.ws;
   this._cleanup();
+  if (ws) {
+    ws.close();
+  }
 };
 
 WebSocketTransport.prototype._cleanup = function() {


### PR DESCRIPTION
Some browsers (e.g. Chrome and Safari) call the `onerror` listener on the WebSocket object if the `close()` method is called before the connection is established.
This creates a race condition in the SockJS client which leads to #344.

This is basically what happens:

- `sockjs.close()` is called when there is a WebSocket handshake in progress.
- [`this._transport.close()`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/main.js#L334) is called
- [`this.ws.close()`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/transport/websocket.js#L70) is called
- The above call makes the [`onerror`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/transport/websocket.js#L54) listener to be called on the same tick
- The [`close`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/main.js#L221) event is emitted and [`sockjs._transportClose()`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/main.js#L290-L304) and [`this._connect()`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/main.js#L299) are called
- The next transport is selected and we go back to `sockjs._close()` where the [`_transport`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/main.js#L335) property is nulled
- [`sockjs._open()`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/main.js#L306-L322) is called, the ready state is no longer `CONNECTING` so [`this.close()`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/main.js#L320) is called
- The transport is not closed as the [`_transport`](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/main.js#L333-L337) property is now `null` and the [error](https://github.com/sockjs/sockjs-client/blob/91e30059cc32c6b41ddd0de05c68681e9b00d503/lib/main.js#L340) is thrown.

This patch fixes the issue by removing the event listeners on the WebSocket object before calling the `close()` method.