### PR TITLE
Remove JSON3 dependency

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -1,8 +1,6 @@
 'use strict';
 
-var JSON3 = require('json3')
-  , iframeUtils = require('./utils/iframe')
-  ;
+var iframeUtils = require('./utils/iframe');
 
 function FacadeJS(transport) {
   this._transport = transport;
@@ -11,7 +9,7 @@ function FacadeJS(transport) {
 }
 
 FacadeJS.prototype._transportClose = function(code, reason) {
-  iframeUtils.postMessage('c', JSON3.stringify([code, reason]));
+  iframeUtils.postMessage('c', JSON.stringify([code, reason]));
 };
 FacadeJS.prototype._transportMessage = function(frame) {
   iframeUtils.postMessage('t', frame);


### PR DESCRIPTION
JSON is supported in many environments now, including the majority or browsers and nodeJS. Including this dependency ±43kb for everyone by default seems wasteful.

Consumers can provide their own polyfill for the platform they need to support that doesn't have JSON?