### PR TITLE
Fix connection close when Transport timeout

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -230,6 +230,10 @@ SockJS.prototype._connect = function() {
 SockJS.prototype._transportTimeout = function() {
   debug('_transportTimeout');
   if (this.readyState === SockJS.CONNECTING) {
+    if (this._transport) {
+      this._transport.close();
+    }
+
     this._transportClose(2007, 'Transport timed out');
   }
 };


### PR DESCRIPTION
Here is my workaround for problem #334 .
Without closing the connection, "eventsource" transport will send request's to server even after "onclose" callback.