### PR TITLE
Wrap the the contentWindow access in a try/catch block when in setTimeout

### DIFF
--- a/lib/utils/iframe.js
+++ b/lib/utils/iframe.js
@@ -71,17 +71,17 @@ module.exports = {
     };
     var post = function(msg, origin) {
       debug('post', msg, origin);
-      try {
-        // When the iframe is not loaded, IE raises an exception
-        // on 'contentWindow'.
-        setTimeout(function() {
+      setTimeout(function() {
+        try {
+          // When the iframe is not loaded, IE raises an exception
+          // on 'contentWindow'.
           if (iframe && iframe.contentWindow) {
             iframe.contentWindow.postMessage(msg, origin);
           }
-        }, 0);
-      } catch (x) {
-        // intentionally empty
-      }
+        } catch (x) {
+          // intentionally empty
+        }
+      }, 0);
     };
 
     iframe.src = iframeUrl;


### PR DESCRIPTION
It's necessary to wrap the code that accesses the conentWindow with a try/catch block to silently ignore the errors in Internet Explorer. 

Wrapping the setTimeout call is not useful.