### PR TITLE
Allow for sending object by parsing them to JSON internally

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -21,6 +21,10 @@ var URL = require('url-parse')
   , InfoReceiver = require('./info-receiver')
   ;
 
+function isObject(value) {
+  return value != null && typeof value === 'object';
+}
+
 var debug = function() {};
 if (process.env.NODE_ENV !== 'production') {
   debug = require('debug')('sockjs-client:main');
@@ -149,9 +153,10 @@ SockJS.prototype.close = function(code, reason) {
 };
 
 SockJS.prototype.send = function(data) {
-  // #13 - convert anything non-string to string
-  // TODO this currently turns objects into [object Object]
-  if (typeof data !== 'string') {
+  if (isObject(data)) {
+    data = JSON3.stringify(data);
+  } else if (typeof data !== 'string') {
+    // #13 - convert anything non-string to string
     data = '' + data;
   }
   if (this.readyState === SockJS.CONNECTING) {


### PR DESCRIPTION
I've spotted the TODO comment in the source code, so I have decided to fix this one.

I wasnt sure for exact semantics about what kind of objects should be allowed to be sent, possibly we need more strict checks. 

Additionally I was wondering if in case of using `JSON.parse` we shouldnt skip `escape.quote`.