### PR TITLE
Fixed crash with react-native@0.45.1 on Android

### DIFF
--- a/lib/transport/browser/abstract-xhr.js
+++ b/lib/transport/browser/abstract-xhr.js
@@ -72,7 +72,7 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
     // Mozilla docs says https://developer.mozilla.org/en/XMLHttpRequest :
     // "This never affects same-site requests."
 
-    this.xhr.withCredentials = 'true';
+    this.xhr.withCredentials = true;
   }
   if (opts && opts.headers) {
     for (var key in opts.headers) {


### PR DESCRIPTION
It looks like because of some strict type checks on Java side code:
`this.xhr.withCredentials = 'true';` 
leads to error: 
`TypeError: expected dynamic type 'boolean', but had type 'string'`.

When I changed `'true'` to `true` the error has gone. 