### PR TITLE
Use boolean instead of string for withCredentials flag

### DIFF
--- a/lib/transport/browser/abstract-xhr.js
+++ b/lib/transport/browser/abstract-xhr.js
@@ -72,7 +72,7 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
     // Mozilla docs says https://developer.mozilla.org/en/XMLHttpRequest :
     // "This never affects same-site requests."
 
-    this.xhr.withCredentials = 'true';
+    this.xhr.withCredentials = true;
   }
   if (opts && opts.headers) {
     for (var key in opts.headers) {


### PR DESCRIPTION
This issue appears in ReactNative (0.46+) for withCredentials flag that defined as a string, but should be boolean.