### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ You should use a version of sockjs-client
 that supports the protocol used by your server. For example:
 
 ```html
-<script src="https://cdn.jsdelivr.net/sockjs/1/sockjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
 ```
 
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.
I updated the links now so you don't forget to do it when you release a new version.

Feel free to ping me if you have any questions regarding this change.