### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ First, you need to load the SockJS JavaScript library. For example, you can
 put that in your HTML head:
 
 ```html
-<script src="https://cdn.jsdelivr.net/sockjs/1/sockjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
 ```
 
 After the script is loaded you can establish a connection with the

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object.",
   "version": "1.1.4",
   "author": "Bryce Kahle",
+  "jsdelivr": "dist/sockjs.min.js",
   "browser": {
     "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
     "eventsource": "./lib/transport/browser/eventsource.js",


### PR DESCRIPTION
Sending another PR, because i didn't notice a link. #404 
I also set the default file to `dist/sockjs.min.js`.