### PR TITLE
#403 Provide SockJS config for minimum transport fallback timeout

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,7 @@ function SockJS(url, protocols, options) {
   }
   this._transportsWhitelist = options.transports;
   this._transportOptions = options.transportOptions || {};
+  this._transportMinTimeout = options.transportMinTimeout || null;
 
   var sessionId = options.sessionId || 8;
   if (typeof sessionId === 'function') {
@@ -208,8 +209,10 @@ SockJS.prototype._connect = function() {
       }
     }
 
-    // calculate timeout based on RTO and round trips. Default to 5s
-    var timeoutMs = (this._rto * Transport.roundTrips) || 5000;
+    // calculate timeout based on RTO and round trips. Default to 5s. Min timeout is null, can be overridden
+    var timeoutMs = (
+        (this._rto > this._transportMinTimeout ? this._rto : this._transportMinTimeout) * Transport.roundTrips
+    ) || 5000;
     this._transportTimeoutId = setTimeout(this._transportTimeout.bind(this), timeoutMs);
     debug('using timeout', timeoutMs);
 


### PR DESCRIPTION
One of our clients experiences a poor network QoS and falling back to xhr makes it even worse. A simple minimum timeout could solve the issue #403 