### PR TITLE
Changed string type 'true' to boolean type true

### DIFF
--- a/dist/sockjs.js
+++ b/dist/sockjs.js
@@ -1541,7 +1541,7 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
     // Mozilla docs says https://developer.mozilla.org/en/XMLHttpRequest :
     // "This never affects same-site requests."
 
-    this.xhr.withCredentials = 'true';
+    this.xhr.withCredentials = true;
   }
   if (opts && opts.headers) {
     for (var key in opts.headers) {


### PR DESCRIPTION
In android, withCredentials = 'true' is creating issue as data type should be boolean instead of string.

Fixes #398 