### PR TITLE
Added link to my .NET port of the SockJS client

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Work in progress:
   * [wai-SockJS](https://github.com/Palmik/wai-sockjs)
   * [SockJS-perl](https://github.com/vti/sockjs-perl)
   * [SockJS-go](https://github.com/igm/sockjs-go/)
+  * [syp.biz.SockJS.NET](https://github.com/sypbiz/SockJS.NET) - .NET port of the SockJS client
 
 Getting Started
 -------


### PR DESCRIPTION
I've implemented a .NET port of the SockJS client based on the JavaScript one.
Adding a link in the readme file