### PR TITLE
fix sockjs#403,add timeoutMs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Where `options` is a hash which can contain:
     If you don't specify this option, the default is to use the default random
     string generator to generate 8-character long session ids.
 
+*  **timeoutMs (number)**
+  
+    Timeout millseconds for transport connection, more information see [this issue](https://github.com/sockjs/sockjs-client/issues/403)
+
 Although the 'SockJS' object tries to emulate the 'WebSocket'
 behaviour, it's impossible to support all of its features. An
 important SockJS limitation is the fact that you're not allowed to

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,7 +49,7 @@ function SockJS(url, protocols, options) {
   }
   this._transportsWhitelist = options.transports;
   this._transportOptions = options.transportOptions || {};
-
+  this._timeoutMs = options.timeoutMs;
   var sessionId = options.sessionId || 8;
   if (typeof sessionId === 'function') {
     this._generateSessionId = sessionId;
@@ -209,7 +209,7 @@ SockJS.prototype._connect = function() {
     }
 
     // calculate timeout based on RTO and round trips. Default to 5s
-    var timeoutMs = (this._rto * Transport.roundTrips) || 5000;
+    var timeoutMs = this._timeoutMs || (this._rto * Transport.roundTrips) || 5000;
     this._transportTimeoutId = setTimeout(this._transportTimeout.bind(this), timeoutMs);
     debug('using timeout', timeoutMs);
 


### PR DESCRIPTION
You can set timeoutMs by options.

Sometimes the connection is very bad,the websocket connection always lost,you can set timeoutMs any value like 60000 then will be ok.