### PR TITLE
Add maximum retries to polling after network error.

### DIFF
--- a/lib/transport/lib/polling.js
+++ b/lib/transport/lib/polling.js
@@ -15,6 +15,7 @@ function Polling(Receiver, receiveUrl, AjaxObject) {
   this.Receiver = Receiver;
   this.receiveUrl = receiveUrl;
   this.AjaxObject = AjaxObject;
+  this.networkRetries = 0;
   this._scheduleReceiver();
 }
 
@@ -26,6 +27,7 @@ Polling.prototype._scheduleReceiver = function() {
   var poll = this.poll = new this.Receiver(this.receiveUrl, this.AjaxObject);
 
   poll.on('message', function(msg) {
+    self.networkRetries = 0;
     debug('message', msg);
     self.emit('message', msg);
   });
@@ -35,7 +37,8 @@ Polling.prototype._scheduleReceiver = function() {
     self.poll = poll = null;
 
     if (!self.pollIsClosing) {
-      if (reason === 'network') {
+      if (reason === 'network' && self.networkRetries < Polling.NETWORK_RETRIES) {
+        self.networkRetries++;
         self._scheduleReceiver();
       } else {
         self.emit('close', code || 1006, reason);
@@ -53,5 +56,7 @@ Polling.prototype.abort = function() {
     this.poll.abort();
   }
 };
+
+Polling.NETWORK_RETRIES = 3;
 
 module.exports = Polling;


### PR DESCRIPTION
A possible solution to #440 

I need that, as that infinite loop is giving a hard time to the load balancer when we have a couple of users having this issue.

What it does is that for every connection request, it stops retrying after 3 unsuccessful requests. It's the consumer's responsibility then to decide what to do (e.g. retry again?)

I'm not fully aware of the internals of this library, so I'm not too sure if this is fully safe to merge in, but it seems to cover the basic use case.