### PR TITLE
fix: allow accessing http://127.0.0.1 from https page

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -74,7 +74,7 @@ function SockJS(url, protocols, options) {
     throw new SyntaxError("The URL's scheme must be either 'http:' or 'https:'. '" + parsedUrl.protocol + "' is not allowed.");
   }
 
-  var secure = parsedUrl.protocol === 'https:';
+  var secure = parsedUrl.protocol === 'https:' || parsedUrl.hostname === '127.0.0.1';
   // Step 2 - don't allow secure origin with an insecure protocol
   if (loc.protocol === 'https:' && !secure) {
     throw new Error('SecurityError: An insecure SockJS connection may not be initiated from a page loaded over HTTPS');


### PR DESCRIPTION
... since 127.0.0.1 is [potentially trustworthy](https://www.w3.org/TR/secure-contexts/#is-origin-trustworthy) and honored by most browsers (chromium & firefox)

fixes #486 