### PR TITLE
Use crypto-browserify instead of crypto

### DIFF
--- a/lib/utils/random.js
+++ b/lib/utils/random.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var crypto = require('crypto');
+var crypto = require('crypto-browserify');
 
 // This string has length 32, a power of 2, so the modulus doesn't introduce a
 // bias.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "faye-websocket": "^0.11.3",
     "inherits": "^2.0.4",
     "json3": "^3.3.3",
-    "url-parse": "^1.5.1"
+    "url-parse": "^1.5.1",
+    "crypto-browserify": "^3.12.0"
   },
   "devDependencies": {
     "browserify": "^16.5.1",


### PR DESCRIPTION
Crypto has been deactivated, and its warehouse is empty, which leads to errors in the browser environment. I strongly recommend adopting my proposal, otherwise I need to do this:

```
const cryptoReplaceFiles = [
  './node_modules/sockjs-client/lib/utils/random.js',
  './node_modules/sockjs-client/dist/sockjs.js',
  './node_modules/sockjs-client/dist/sockjs.js.map',
  './node_modules/sockjs-client/dist/sockjs.min.js',
  './node_modules/sockjs-client/dist/sockjs.min.js.map'
]
cryptoReplaceFiles.forEach((filePath) => {
  fs.readFile(filePath, 'utf8', function (err, data) {
    if (err) return console.log(err)
    const result = data.replace(/\(['"]crypto['"]\)/g, "('crypto-browserify')")
    fs.writeFile(filePath, result, 'utf8', function (err) {
      if (err) return console.log(err)
    })
  })
})
```