### PR TITLE
url-parse security vulnerability issue update to ^1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "faye-websocket": "^0.11.3",
     "inherits": "^2.0.4",
     "json3": "^3.3.3",
-    "url-parse": "^1.5.1"
+    "url-parse": "^1.5.2"
   },
   "devDependencies": {
     "browserify": "^16.5.1",


### PR DESCRIPTION
This solves the security vulnerability issue from 1.5.1 of url-parse dependency.
[https://github.com/sockjs/sockjs-client/issues/550](https://github.com/sockjs/sockjs-client/issues/550)

The issue:
[https://snyk.io/test/npm/url-parse/1.5.1](https://snyk.io/test/npm/url-parse/1.5.1)
[https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-3664](https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-3664)

Huntr thread confirming it:
[https://huntr.dev/bounties/1625557993985-unshiftio/url-parse](https://huntr.dev/bounties/1625557993985-unshiftio/url-parse)

Thank you, @peasandwell @iorrah