### PR TITLE
Update eventsource due to CVE-2022-1650

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "eventsource": "^1.1.0",
+        "eventsource": "^2.0.2",
         "faye-websocket": "^0.11.4",
         "inherits": "^2.0.4",
         "url-parse": "^1.5.10"
@@ -2787,14 +2787,11 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
-      "dependencies": {
-        "original": "^1.0.0"
-      },
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "engines": {
-        "node": ">=0.12.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/evp_bytestokey": {
@@ -6406,14 +6403,6 @@
       "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
-      "dependencies": {
-        "url-parse": "^1.4.3"
       }
     },
     "node_modules/os-browserify": {
@@ -11830,12 +11819,9 @@
       "dev": true
     },
     "eventsource": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
-      "requires": {
-        "original": "^1.0.0"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -14662,14 +14648,6 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
-      }
-    },
-    "original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
-      "requires": {
-        "url-parse": "^1.4.3"
       }
     },
     "os-browserify": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "debug": "^3.2.7",
-    "eventsource": "^1.1.0",
+    "eventsource": "^2.0.2",
     "faye-websocket": "^0.11.4",
     "inherits": "^2.0.4",
     "url-parse": "^1.5.10"


### PR DESCRIPTION
All tests passing with `npm run test:browser_local`