### PR TITLE
Use the provided timeout option, if set, for the InfoReceiver. ⏰

### DIFF
--- a/lib/info-receiver.js
+++ b/lib/info-receiver.js
@@ -16,13 +16,13 @@ if (process.env.NODE_ENV !== 'production') {
   debug = require('debug')('sockjs-client:info-receiver');
 }
 
-function InfoReceiver(baseUrl, urlInfo) {
+function InfoReceiver(baseUrl, urlInfo, timeout) {
   debug(baseUrl);
   var self = this;
   EventEmitter.call(this);
 
   setTimeout(function() {
-    self.doXhr(baseUrl, urlInfo);
+    self.doXhr(baseUrl, urlInfo, timeout);
   }, 0);
 }
 
@@ -47,7 +47,7 @@ InfoReceiver._getReceiver = function(baseUrl, url, urlInfo) {
   return new InfoAjax(url, XHRFake);
 };
 
-InfoReceiver.prototype.doXhr = function(baseUrl, urlInfo) {
+InfoReceiver.prototype.doXhr = function(baseUrl, urlInfo, timeout) {
   var self = this
     , url = urlUtils.addPath(baseUrl, '/info')
     ;
@@ -55,11 +55,14 @@ InfoReceiver.prototype.doXhr = function(baseUrl, urlInfo) {
 
   this.xo = InfoReceiver._getReceiver(baseUrl, url, urlInfo);
 
+  if (timeout === undefined) {
+    timeout = InfoReceiver.timeout
+  }
   this.timeoutRef = setTimeout(function() {
     debug('timeout');
     self._cleanup(false);
     self.emit('finish');
-  }, InfoReceiver.timeout);
+  }, timeout);
 
   this.xo.once('finish', function(info, rtt) {
     debug('finish', info, rtt);

--- a/lib/main.js
+++ b/lib/main.js
@@ -121,7 +121,7 @@ function SockJS(url, protocols, options) {
   , sameScheme: urlUtils.isSchemeEqual(this.url, loc.href)
   };
 
-  this._ir = new InfoReceiver(this.url, this._urlInfo);
+  this._ir = new InfoReceiver(this.url, this._urlInfo, options.timeout);
   this._ir.once('finish', this._receiveInfo.bind(this));
 }
 


### PR DESCRIPTION
We have some users with truly terrible internet connections.  From time to time, the InfoReceiver times out for them.  We'd like to be able to configure a longer timeout for the InfoReceiver, instead of the hardcoded 8000ms.

This PR accomplishes this.  However, I haven't used javascript for years, and am a little uncertain if there is a simple and reliable way to unit test the addition of this configurable timeout.  I'd be happy to figure it out if given some guidance.

I'm also unsure if I should build dist/sockjs for the PR and if so, how to do it.