### PR TITLE
Add a watchdog for the heartbeat

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -172,6 +172,7 @@ SockJS.CONNECTING = 0;
 SockJS.OPEN = 1;
 SockJS.CLOSING = 2;
 SockJS.CLOSED = 3;
+SockJS.WATCHDOG_WEBSOCKET_TIMEOUT = 30000; // The heartbeat appears every 25 seconds, so we have 5 seconds delay buffer
 
 SockJS.prototype._receiveInfo = function(info, rtt) {
   debug('_receiveInfo', rtt);

--- a/lib/main.js
+++ b/lib/main.js
@@ -241,6 +241,11 @@ SockJS.prototype._transportTimeout = function() {
   }
 };
 
+SockJS.prototype._websocketWatchdogCb = function(websocket) {
+  debug("watchdog websocket timeout");
+  websocket._close(1006, 'Server lost session');
+}
+
 SockJS.prototype._transportMessage = function(msg) {
   debug('_transportMessage', msg);
   var self = this
@@ -257,6 +262,8 @@ SockJS.prototype._transportMessage = function(msg) {
     case 'h':
       this.dispatchEvent(new Event('heartbeat'));
       debug('heartbeat', this.transport);
+      clearTimeout(this.heartbeatWatchdog);
+      this.heartbeatWatchdog = setTimeout(this._websocketWatchdogCb, SockJS.WATCHDOG_WEBSOCKET_TIMEOUT, this);
       return;
   }
 
@@ -321,6 +328,7 @@ SockJS.prototype._open = function() {
     this.transport = this._transport.transportName;
     this.dispatchEvent(new Event('open'));
     debug('connected', this.transport);
+    this.heartbeatWatchdog = setTimeout(this._websocketWatchdogCb, SockJS.WATCHDOG_WEBSOCKET_TIMEOUT, this);
   } else {
     // The server might have been restarted, and lost track of our
     // connection.


### PR DESCRIPTION
If your client device loose the network connection to the device running the websocket server this will not be detected by the socket client.
This watchdog will be reseted by the heartbeat message (appears every 25 seconds) if the watchdog will not be resetted in a 30 second window the connection can be marked as lost => 1006

Found with OctoPrint, if you connect to the OctoPrint instance with a laptop and this goes to sleep mode for some time (network will be disabled)
After you wake the device again you still see the UI but the websocket connection is not connected anymore.

You can reproduce this by disabling your network on the laptop, wait some time and connect again.