### PR TITLE
fixes for disonnect and decode

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -297,9 +297,11 @@ SockJS.prototype._transportMessage = function(msg) {
 SockJS.prototype._transportClose = function(code, reason) {
   debug('_transportClose', this.transport, code, reason);
   if (this._transport) {
+    clearTimeout(this._transportTimeoutId);
     this._transport.removeAllListeners();
     this._transport = null;
     this.transport = null;
+    this._transportTimeoutId = null;
   }
 
   if (!userSetCode(code) && code !== 2000 && this.readyState === SockJS.CONNECTING) {

--- a/lib/transport/receiver/eventsource.js
+++ b/lib/transport/receiver/eventsource.js
@@ -10,6 +10,10 @@ if (process.env.NODE_ENV !== 'production') {
   debug = require('debug')('sockjs-client:receiver:eventsource');
 }
 
+function decodeURISafe(s) {
+    return decodeURI(s.replace(/%(?![0-9][0-9a-fA-F]+)/g, '%25'));
+}
+
 function EventSourceReceiver(url) {
   debug(url);
   EventEmitter.call(this);
@@ -18,7 +22,7 @@ function EventSourceReceiver(url) {
   var es = this.es = new EventSourceDriver(url);
   es.onmessage = function(e) {
     debug('message', e.data);
-    self.emit('message', decodeURI(e.data));
+    self.emit('message', decodeURISafe(e.data));
   };
   es.onerror = function(e) {
     debug('error', es.readyState, e);

--- a/tests/lib/receivers.js
+++ b/tests/lib/receivers.js
@@ -2,6 +2,7 @@
 
 var expect = require('expect.js')
   , JsonpReceiver = require('../../lib/transport/receiver/jsonp')
+  , EventSourceReceiver = require('../../lib/transport/receiver/eventsource')
   , XhrReceiver = require('../../lib/transport/receiver/xhr')
   , XhrFake = require('../../lib/transport/sender/xhr-fake')
   , utils = require('../../lib/utils/iframe')
@@ -286,6 +287,42 @@ describe('Receivers', function () {
         done();
       });
       xhr.abort();
+    });
+  });
+
+  describe('eventsource', function () {
+    it('receives data', function(done) {
+      var eventSourceReceiver = new EventSourceReceiver('test');
+
+      eventSourceReceiver.on('message', function(msg) {
+        try {
+          expect(msg).to.equal('datadataaa');
+        } catch (e) {}
+        eventSourceReceiver.abort();
+        done();
+      });
+
+      eventSourceReceiver.es.dispatchEvent({
+        type: 'message',
+        detail: { data:  'datadataaa' }
+      })
+    });
+
+    it('correctly escapes characters', function(done) {
+      var eventSourceReceiver = new EventSourceReceiver('test');
+
+      eventSourceReceiver.on('message', function(msg) {
+        try {
+          expect(msg).to.equal('{ \\"lastName\\":\\"#@%!~`%^&*()\\" }');
+        } catch (e) {}
+        eventSourceReceiver.abort();
+        done();
+      });
+
+      eventSourceReceiver.es.dispatchEvent({
+        type: 'message',
+        detail: { data:  '{ \\"lastName\\":\\"#@%!~`%^&*()\\" }' }
+      })
     });
   });
 });


### PR DESCRIPTION
[fix: fix for extremely rare json decode issue](https://github.com/sockjs/sockjs-client/commit/108eeb845cef327edf49c981bf4b9c900557b27e)
[fix: prevent breaking next transport timeout if previous transport fa…](https://github.com/sockjs/sockjs-client/commit/a750ffe529820505e13d3ac2a79926f039c0d186) 

this PR contains 2 bugfixes we implemented in our sockjs fork. they never got merged as previous owner declined them since he couldn't reproduce the issue.

Decode issue occurs in rare occasions with spring boot sockjs integration. Sometimes sockjs was not able to parse message correctly.

Second issue is little bit easier to reproduce. If we set transports to
`[ 'eventsource', 'iframe', 'htmlfile', 'xhr-streaming',]`
and them block with ublock eventsource, xhr, xhr_streaming them xhr when failing does not clear its timeout and when next transport kicks in then it's after ~ 20ms being cleared by previous transport timeout. This clears the timeout if the transport failed before its timeout kicked in. Currently if transport fails before its timeout then the next transport is being initialised with new timeout but the old timeout is still in a queue.

Take it or drop it.