### PR TITLE
Explicitly enable stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,4 +17,4 @@ jobs:
         days-before-close: 5
         stale-issue-message: 'This issue has been inactive for 30 days. It will be in closed in 5 days without any new activity.'
         stale-issue-label: 'no-issue-activity'
-        exempt-issue-labels: 'discussion,work-in-progress'
+        any-of-labels: 'inactive'


### PR DESCRIPTION
Will enable stale workflow only when issue has `inactive` label.

Maybe will help to avoid things like this: https://github.com/sockjs/sockjs-client/issues/612. Or like this: https://github.com/sockjs/sockjs-client/issues/605 - when backwards compatibility broke and nobody cares. And reduce user distraction when valid issues are closed without any comment from the maintainer.